### PR TITLE
Add Enum to Schema generation

### DIFF
--- a/json_schema_to_class.py
+++ b/json_schema_to_class.py
@@ -266,6 +266,7 @@ class Parser:
 
     def generate(self, schema: dict) -> str:
         Array.use_list = False
+        Array.use_enum = False
         result = []
         for _, definition in self.definitions.items():
             result.append(definition.to_class_code(level=0))

--- a/json_schema_to_class.py
+++ b/json_schema_to_class.py
@@ -198,7 +198,7 @@ class Enum(Array):
     def to_init_code(self) -> str:
         Array.use_enum = True
 
-        return '{spaces}self.{name}: {class_name} = self.{class_name}(values.get("{name}", {default}}))'.format(
+        return '{spaces}self.{name}: {class_name} = self.{class_name}(values.get("{name}", "{default}"))'.format(
             spaces=spaces(2),
             name=self.name,
             class_name=self.class_name(),

--- a/json_schema_to_class.py
+++ b/json_schema_to_class.py
@@ -198,10 +198,11 @@ class Enum(Array):
     def to_init_code(self) -> str:
         Array.use_enum = True
 
-        return '{spaces}self.{name}: {class_name} = self.{class_name}(values.get("{name}", None))'.format(
+        return '{spaces}self.{name}: {class_name} = self.{class_name}(values.get("{name}", {default}}))'.format(
             spaces=spaces(2),
             name=self.name,
             class_name=self.class_name(),
+            default=self.default
         )
 
     def to_class_code(self, level: int = 0, schema: dict = None) -> str:

--- a/tests/test_json_schema_to_class.py
+++ b/tests/test_json_schema_to_class.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import unittest
 from pathlib import Path
+from enum import Enum
 
 import json_schema_to_class
 

--- a/tests/test_json_schema_to_class.py
+++ b/tests/test_json_schema_to_class.py
@@ -70,19 +70,20 @@ class MyTestCase(unittest.TestCase):
         self.assertTrue(True)
 
     def test_enum(self):
-        def parse_empty_definition():
-            parser = json_schema_to_class.Parser()
-            parser.parse(schema={
-                'title': 'days',
-                'type': 'object',
-                'properties': {
-                    'mode': {
-                        'enum': ['cosine', 'linear', 0]
-                    }
+        parser = json_schema_to_class.Parser()
+        parser.parse(schema={
+            'title': 'days',
+            'type': 'object',
+            'properties': {
+                'mode': {
+                    'enum': ['cosine', 'linear', 0]
                 }
-            })
+            }
+        })
 
-        self.assertRaises(AssertionError, parse_empty_definition)
+        code = parser.root.to_class_code()
+        exec(code)
+        self.assertTrue(True)
 
     def test_parse(self):
         def parse_empty_definition():

--- a/tests/test_json_schema_to_class.py
+++ b/tests/test_json_schema_to_class.py
@@ -76,7 +76,8 @@ class MyTestCase(unittest.TestCase):
             'type': 'object',
             'properties': {
                 'mode': {
-                    'enum': ['cosine', 'linear', 0]
+                    'type': "string",
+                    'enum': ['cosine', 'linear']
                 }
             }
         })

--- a/tests/test_schema.json
+++ b/tests/test_schema.json
@@ -24,6 +24,7 @@
       "type": "object",
       "properties": {
         "lr_mode": {
+          "type": "string",
           "enum": [
             "step",
             "cos"


### PR DESCRIPTION
Hello, noticed that the `enum` logic was setup but not fully implemented so I went ahead and implemented it. I'm not super familiar with this repository, so I don't know how to fully test this but it worked well with the file I used against it (which I can attach, it's a bit large), but here's an example of the output I am now receiving after implementing it.

```
"assetType": {
"type": "string",
"enum": [
    "EQUITY",
    "OPTION",
    "INDEX",
    "MUTUAL_FUND",
    "CASH_EQUIVALENT",
    "FIXED_INCOME",
    "CURRENCY"
]
```

generates (See latest comment)

```
class Assettype(Enum):
    Equity = "EQUITY"
    Option = "OPTION"
    Index = "INDEX"
    Mutual_fund = "MUTUAL_FUND"
    Cash_equivalent = "CASH_EQUIVALENT"
    Fixed_income = "FIXED_INCOME"
    Currency = "CURRENCY"
```

I am concerned about backwards compatibility, as those who have used this library previously may not be able to handle the conversion from `str` to `Enum` (since they'd need to do `.value`. Would you recommend adding a argument to explicitly enable this behavior?

Addresses https://github.com/FebruaryBreeze/json-schema-to-class/issues/19